### PR TITLE
Register object before the service gets exposed on DBus

### DIFF
--- a/TelepathyQt/dbus-service.cpp
+++ b/TelepathyQt/dbus-service.cpp
@@ -164,21 +164,22 @@ bool DBusService::registerObject(const QString &busName, const QString &objectPa
         return true;
     }
 
-    if (!mPriv->dbusObject->dbusConnection().registerService(busName)) {
-        error->set(TP_QT_ERROR_INVALID_ARGUMENT,
-                QString(QLatin1String("Name %1 already in use by another process"))
-                    .arg(busName));
-        warning() << "Unable to register service" << busName <<
-            "- name already registered by another process";
-        return false;
-    }
-
     if (!mPriv->dbusObject->dbusConnection().registerObject(objectPath, mPriv->dbusObject)) {
         error->set(TP_QT_ERROR_INVALID_ARGUMENT,
                 QString(QLatin1String("Object at path %1 already registered"))
                     .arg(objectPath));
         warning() << "Unable to register object" << objectPath <<
             "- path already registered";
+        return false;
+    }
+
+    if (!mPriv->dbusObject->dbusConnection().registerService(busName)) {
+        mPriv->dbusObject->dbusConnection().unregisterObject(objectPath);
+        error->set(TP_QT_ERROR_INVALID_ARGUMENT,
+                QString(QLatin1String("Name %1 already in use by another process"))
+                    .arg(busName));
+        warning() << "Unable to register service" << busName <<
+            "- name already registered by another process";
         return false;
     }
 


### PR DESCRIPTION
This is required for services to get properly registered when using QtDBus >= 5.6