### PR TITLE
Farstream/CMakeLists.txt: Add dbus-glib include path

### DIFF
--- a/TelepathyQt/Farstream/CMakeLists.txt
+++ b/TelepathyQt/Farstream/CMakeLists.txt
@@ -5,6 +5,7 @@ if(FARSTREAM_COMPONENTS_FOUND)
                         ${GSTREAMER_INCLUDE_DIRS}
                         ${GLIB2_INCLUDE_DIR}
                         ${LIBXML2_INCLUDE_DIR}
+                        ${DBUS_GLIB_INCLUDE_DIR}
                         ${DBUS_INCLUDE_DIR})
 
     # It gets inherited from the previous directory, hence it has to be removed explicitely

--- a/cmake/modules/FindDBusGLib.cmake
+++ b/cmake/modules/FindDBusGLib.cmake
@@ -29,7 +29,7 @@ if(NOT WIN32)
 endif(NOT WIN32)
 
 find_path(DBUS_GLIB_INCLUDE_DIR
-          NAMES dbus-1.0/dbus/dbus-glib.h
+          NAMES dbus/dbus-glib.h
           HINTS
           ${PC_DBUS_GLIB_INCLUDEDIR}
           ${PC_DBUS_GLIB_INCLUDE_DIRS}
@@ -42,9 +42,8 @@ find_path(DBUS_GLIB_LOWLEVEL_INCLUDE_DIR
           ${PC_DBUS_GLIB_INCLUDE_DIRS}
 )
 
-# HACK! Workaround appending "/dbus-1.0" to the HINTS above not working for some reason.
 set(DBUS_GLIB_INCLUDE_DIRS
-    "${DBUS_GLIB_INCLUDE_DIR}/dbus-1.0" "${DBUS_GLIB_LOWLEVEL_INCLUDE_DIR}"
+    "${DBUS_GLIB_INCLUDE_DIR}" "${DBUS_GLIB_LOWLEVEL_INCLUDE_DIR}"
 )
 
 find_library(DBUS_GLIB_LIBRARIES


### PR DESCRIPTION
On traditional systems, both `DBUS_GLIB_INCLUDE_DIR` and `DBUS_INCLUDE_DIR` point to something like `/usr/include/dbus-1.0`. This does need to be the case though – for example, Nix installs each library to a separate directory in the Nix store.

Additionally, since CMake uses its own hacky scripts instead of actually obtaining the correct flags from pkgconfig, the `DBUS_GLIB_INCLUDE_DIR` did not contain the `dbus-1.0` path.

This patch fixes the `DBUS_GLIB_INCLUDE_DIR` variable and then adds it to `include_directories` for Farstream.

Closes: #25